### PR TITLE
Remove 'callbacks' argument from Client.on_disconnect

### DIFF
--- a/brukva/client.py
+++ b/brukva/client.py
@@ -339,7 +339,7 @@ class Client(object):
         if self.selected_db:
             self.select(self.selected_db)
 
-    def on_disconnect(self, callbacks):
+    def on_disconnect(self):
         raise ConnectionError("Socket closed on remote end")
     ####
 


### PR DESCRIPTION
Connection.on_disconnect is called without parameters (e.g. in Connecition.read) but Client.on_disconnect have required (and unused) 'callbacks' argument and this causes TypeErrors. 
